### PR TITLE
Ensure first() and last() methods return null if collection empty

### DIFF
--- a/src/AbstractImmutableCollection.php
+++ b/src/AbstractImmutableCollection.php
@@ -70,19 +70,19 @@ abstract class AbstractImmutableCollection implements ImmutableCollection
     }
 
     /**
-     * @return TValue|false
+     * @return TValue|null
      */
     public function first()
     {
-        return reset($this->items);
+        return reset($this->items) ?: null;
     }
 
     /**
-     * @return TValue|false
+     * @return TValue|null
      */
     public function last()
     {
-        return end($this->items);
+        return end($this->items) ?: null;
     }
 
     /**

--- a/tests/unit/CollectionTest.php
+++ b/tests/unit/CollectionTest.php
@@ -53,6 +53,13 @@ final class CollectionTest extends TestCase
         $this->assertSame($collectionItem1, $sut->first());
     }
 
+    public function test_first_returns_null_if_collection_is_empty(): void
+    {
+        $sut = new DummyCollection([]);
+
+        $this->assertNull($sut->first());
+    }
+
     public function test_last_returns_last_item(): void
     {
         $collectionItem1 = new DummyCollectionItem();
@@ -62,6 +69,13 @@ final class CollectionTest extends TestCase
         $sut = new DummyCollection([$collectionItem1, $collectionItem2, $collectionItem3]);
 
         $this->assertSame($collectionItem3, $sut->last());
+    }
+
+    public function test_last_returns_null_if_collection_is_empty(): void
+    {
+        $sut = new DummyCollection([]);
+
+        $this->assertNull($sut->last());
     }
 
     public function test_equality_check_succeeds_correctly(): void


### PR DESCRIPTION
It is much more consistent for these methods to return null if the collection is empty.